### PR TITLE
WOWS listing fixes

### DIFF
--- a/wargaming/wows_encyclopedia_ships.go
+++ b/wargaming/wows_encyclopedia_ships.go
@@ -16,7 +16,7 @@ import (
 //
 // realm:
 //     Valid realms: RealmAsia, RealmEu, RealmNa
-func (service *WowsService) EncyclopediaShips(ctx context.Context, realm Realm, options *wows.EncyclopediaShipsOptions) (*wows.EncyclopediaShips, error) {
+func (service *WowsService) EncyclopediaShips(ctx context.Context, realm Realm, options *wows.EncyclopediaShipsOptions) (map[int]*wows.EncyclopediaShips, error) {
 	if err := validateRealm(realm, []Realm{RealmAsia, RealmEu, RealmNa}); err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (service *WowsService) EncyclopediaShips(ctx context.Context, realm Realm, 
 		}
 	}
 
-	var data *wows.EncyclopediaShips
+	var data map[int]*wows.EncyclopediaShips
 	err := service.client.getRequest(ctx, sectionWows, realm, "/encyclopedia/ships/", reqParam, &data)
 	return data, err
 }

--- a/wargaming/wows_ships_stats.go
+++ b/wargaming/wows_ships_stats.go
@@ -18,7 +18,7 @@ import (
 //     Valid realms: RealmAsia, RealmEu, RealmNa
 // accountId:
 //     Player account ID
-func (service *WowsService) ShipsStats(ctx context.Context, realm Realm, accountId int, options *wows.ShipsStatsOptions) (*wows.ShipsStats, error) {
+func (service *WowsService) ShipsStats(ctx context.Context, realm Realm, accountId int, options *wows.ShipsStatsOptions) (map[int][]*wows.ShipsStats, error) {
 	if err := validateRealm(realm, []Realm{RealmAsia, RealmEu, RealmNa}); err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (service *WowsService) ShipsStats(ctx context.Context, realm Realm, account
 		}
 	}
 
-	var data *wows.ShipsStats
+	var data map[int][]*wows.ShipsStats
 	err := service.client.getRequest(ctx, sectionWows, realm, "/ships/stats/", reqParam, &data)
 	return data, err
 }


### PR DESCRIPTION
Hello, thanks for the project.

While using the library, I encountered errors in two wows listings.

I've done the following fixes, but I'm not sure this follows the design principals of this library.

* Switch *wows.ShipsStats -> map[int][]*wows.ShipsStats

The response of '/wows/ships/stats/' looks like:
```json
{
    "status": "ok",
    "meta": {
        "count": 1,
        "hidden": null
    },
    "data": {
        "123183423": [
            {
                "ship_id": 3668883440
            },
            {
                "ship_id": 3763222224
            }
        ]
    }
}
```

(note: request with fields = ["ship_id"] and 2 specific ships)

* Switch *wows.EncyclopediaShips -> map[int]*wows.EncyclopediaShips

The response of /encyclopedia/ships/ looks like:
```json
{
  "status": "ok",
  "meta":{
    "count":2,
    "page_total":304,
    "total":608,
    "limit":2,
    "page":1},
  "data":{
     "3315513040":{"ship_id": 3315513040, "name":"[Zaō]"},
     "3332323024":{"ship_id": 3332323024, "name":"[Yamato]"}
  }
}
```
(note: request with limit = 2 and fields = ["name", "ship_id"])