### PR TITLE
[api] Fix return type of WoWs clans info

### DIFF
--- a/tools/generator/internal/patches.go
+++ b/tools/generator/internal/patches.go
@@ -73,6 +73,8 @@ func patchEndpoint(ep *endpoint) {
 		ep.DataType.TypeStr = "map[int]" + ep.DataType.TypeStr
 	case "wows_ships_stats":
 		ep.DataType.TypeStr = "map[int][]" + ep.DataType.TypeStr
+	case "wows_clans_info":
+		ep.DataType.TypeStr = "map[int]" + ep.DataType.TypeStr
 	}
 
 	if contains([]string{

--- a/wargaming/wows_clans_info.go
+++ b/wargaming/wows_clans_info.go
@@ -14,10 +14,13 @@ import (
 // https://developers.wargaming.net/reference/all/wows/clans/info
 //
 // realm:
-//     Valid realms: RealmAsia, RealmEu, RealmNa
+//
+//	Valid realms: RealmAsia, RealmEu, RealmNa
+//
 // clanId:
-//     Clan ID. Maximum limit: 100. Min value is 1.
-func (service *WowsService) ClansInfo(ctx context.Context, realm Realm, clanId []int, options *wows.ClansInfoOptions) (*wows.ClansInfo, error) {
+//
+//	Clan ID. Maximum limit: 100. Min value is 1.
+func (service *WowsService) ClansInfo(ctx context.Context, realm Realm, clanId []int, options *wows.ClansInfoOptions) (map[int]*wows.ClansInfo, error) {
 	if err := validateRealm(realm, []Realm{RealmAsia, RealmEu, RealmNa}); err != nil {
 		return nil, err
 	}
@@ -38,7 +41,7 @@ func (service *WowsService) ClansInfo(ctx context.Context, realm Realm, clanId [
 		}
 	}
 
-	var data *wows.ClansInfo
+	var data map[int]*wows.ClansInfo
 	err := service.client.getRequest(ctx, sectionWows, realm, "/clans/info/", reqParam, &data, nil)
 	return data, err
 }

--- a/wargaming/wows_clans_info.go
+++ b/wargaming/wows_clans_info.go
@@ -14,12 +14,9 @@ import (
 // https://developers.wargaming.net/reference/all/wows/clans/info
 //
 // realm:
-//
-//	Valid realms: RealmAsia, RealmEu, RealmNa
-//
+//     Valid realms: RealmAsia, RealmEu, RealmNa
 // clanId:
-//
-//	Clan ID. Maximum limit: 100. Min value is 1.
+//     Clan ID. Maximum limit: 100. Min value is 1.
 func (service *WowsService) ClansInfo(ctx context.Context, realm Realm, clanId []int, options *wows.ClansInfoOptions) (map[int]*wows.ClansInfo, error) {
 	if err := validateRealm(realm, []Realm{RealmAsia, RealmEu, RealmNa}); err != nil {
 		return nil, err


### PR DESCRIPTION
clans info can return several clans in the form of a map `{<clan_id>: {<DATA>}`.

Example:

```
https://api.worldofwarships.eu/wows/clans/info/?application_id=<app_id>&clan_id=500139805%2C500140039&fields=name
```

```json
{
    "status": "ok",
    "meta": {
        "count": 2
    },
    "data": {
        "500139805": {
            "name": "PONYHOF - Life is not all guns and roses."
        },
        "500140039": {
            "name": "TheDrunkenSunken"
        }
    }

}
```

* added a patch case in tools/generator/internal/patches.go
* commit the updated wargaming/wows_clans_info.go (map[int]*wows.ClansInfo instead of *wows.ClansInfo for the return)

note: all the files got non-significant changes like:
```diff
-//     Valid realms: RealmAsia, RealmEu, RealmNa
+//
+//     Valid realms: RealmAsia, RealmEu, RealmNa
```

But I've not commited them (to not clutter the commit)