### PR TITLE
[gen] Fixing permissions on generated directories

### DIFF
--- a/tools/generator/internal/generator.go
+++ b/tools/generator/internal/generator.go
@@ -48,7 +48,7 @@ func (gen *Generator) Generate() (err error) {
 		// init section
 		sectionsMap[snakeToCamel(game.Slug)] = &sectionData{Name: snakeToCamel(game.Slug), LongName: game.Name}
 
-		err = os.MkdirAll(filepath.Join(gen.outputPath, game.Slug), 0664)
+		err = os.MkdirAll(filepath.Join(gen.outputPath, game.Slug), 0755)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
With Unix permissions, directories generally need to be executable, putting 0755 (`drwxr-xr-x`)

Otherwise I get the following running the generator:

```
(001/180) Generating wot_account_list
    patching
    create method file
    create struct file
open ./wargaming/wot/account_list.go: permission denied
```

Also, small suggestion: add the `generator` binary in the gitignore (to avoid accidental commit/push of this file)