### PR TITLE
[api] Fix generator and generated code for wows_account_info and wows_clans_accountinfo

### DIFF
--- a/tools/_generator/internal/patches.go
+++ b/tools/_generator/internal/patches.go
@@ -75,6 +75,10 @@ func patchEndpoint(ep *endpoint) {
 		ep.DataType.TypeStr = "map[int][]" + ep.DataType.TypeStr
 	case "wows_clans_info":
 		ep.DataType.TypeStr = "map[int]" + ep.DataType.TypeStr
+	case "wows_clans_accountinfo":
+		ep.DataType.TypeStr = "map[int]" + ep.DataType.TypeStr
+	case "wows_account_info":
+		ep.DataType.TypeStr = "map[int]" + ep.DataType.TypeStr
 	}
 
 	if contains([]string{

--- a/wargaming/wows_account_info.go
+++ b/wargaming/wows_account_info.go
@@ -17,7 +17,7 @@ import (
 //     Valid realms: RealmAsia, RealmEu, RealmNa
 // accountId:
 //     Player account ID. Maximum limit: 100. Min value is 1.
-func (service *WowsService) AccountInfo(ctx context.Context, realm Realm, accountId []int, options *wows.AccountInfoOptions) (*wows.AccountInfo, *GenericMeta, error) {
+func (service *WowsService) AccountInfo(ctx context.Context, realm Realm, accountId []int, options *wows.AccountInfoOptions) (map[int]*wows.AccountInfo, *GenericMeta, error) {
 	if err := validateRealm(realm, []Realm{RealmAsia, RealmEu, RealmNa}); err != nil {
 		return nil, nil, err
 	}
@@ -41,7 +41,7 @@ func (service *WowsService) AccountInfo(ctx context.Context, realm Realm, accoun
 		}
 	}
 
-	var data *wows.AccountInfo
+	var data map[int]*wows.AccountInfo
 	var metaData *GenericMeta
 	err := service.client.getRequest(ctx, sectionWows, realm, "/account/info/", reqParam, &data, &metaData)
 	return data, metaData, err

--- a/wargaming/wows_clans_accountinfo.go
+++ b/wargaming/wows_clans_accountinfo.go
@@ -17,7 +17,7 @@ import (
 //     Valid realms: RealmAsia, RealmEu, RealmNa
 // accountId:
 //     Account ID. Maximum limit: 100. Min value is 1.
-func (service *WowsService) ClansAccountinfo(ctx context.Context, realm Realm, accountId []int, options *wows.ClansAccountinfoOptions) (*wows.ClansAccountinfo, *GenericMeta, error) {
+func (service *WowsService) ClansAccountinfo(ctx context.Context, realm Realm, accountId []int, options *wows.ClansAccountinfoOptions) (map[int]*wows.ClansAccountinfo, *GenericMeta, error) {
 	if err := validateRealm(realm, []Realm{RealmAsia, RealmEu, RealmNa}); err != nil {
 		return nil, nil, err
 	}
@@ -38,7 +38,7 @@ func (service *WowsService) ClansAccountinfo(ctx context.Context, realm Realm, a
 		}
 	}
 
-	var data *wows.ClansAccountinfo
+	var data map[int]*wows.ClansAccountinfo
 	var metaData *GenericMeta
 	err := service.client.getRequest(ctx, sectionWows, realm, "/clans/accountinfo/", reqParam, &data, &metaData)
 	return data, metaData, err


### PR DESCRIPTION
As seen in other Pull Requests (ex: https://github.com/IceflowRE/go-wargaming/pull/3)

These two endpoints return a map `{<player_id>: {<INFO>}` under `data`.

This commit patches the generator and the generated code.